### PR TITLE
Change the colors of sample code 

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,12 +545,12 @@ d3.select("#version").text(" (" + d3.version + ")");
 <pre><code>var paragraphs = document.getElementsByTagName("p");
 for (var i = 0; i &lt; paragraphs.length; i++) {
   var paragraph = paragraphs.item(i);
-  paragraph.style.setProperty("color", "white", null);
+  paragraph.style.setProperty("color", "blue", null);
 }</code></pre>
 
 <p>D3 employs a declarative approach, operating on arbitrary sets of nodes called <i>selections</i>. For example, you can rewrite the above loop as:
 
-<pre><code>d3.selectAll("p").style("color", "white");</code></pre>
+<pre><code>d3.selectAll("p").style("color", "blue");</code></pre>
 
 <p>Yet, you can still manipulate individual nodes as needed:
 


### PR DESCRIPTION
There is a code like the one below in the sample code listed in the Introduction.

``` javascript
var paragraphs = document.getElementsByTagName("p");
for (var i = 0; i < paragraphs.length; i++) {
  var paragraph = paragraphs.item(i);
  paragraph.style.setProperty("color", "white", null);
}
```

``` javascript
d3.selectAll("p").style("color", "white");
```

Both of the code sets the color of the characters to "white". But If the color of the character is white, it becomes the same color as the background color. 
In that case, it looks as if nothing were displayed.

If it is "red" or "blue", I think that people will be less confused because can be seen immediately.
