### PR TITLE
Remove Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,15 +671,3 @@ p.exit().remove();</code></pre>
 <a href="https://github.com/d3/d3"><img style="position:fixed;top:0;right:0;border:0;z-index:2;" width="149" height="149" src="forkme.png" alt="Fork me on GitHub"></a>
 
 <script src="highlight.v9.min.js"></script>
-<script>
-
-GoogleAnalyticsObject = "ga", ga = function() { ga.q.push(arguments); }, ga.q = [], ga.l = +new Date;
-ga("create", "UA-48272912-2", "d3js.org");
-ga("send", "pageview");
-
-hljs.configure({classPrefix: ""});
-d3.selectAll("code:not([class])").classed("javascript", 1);
-d3.selectAll("code").each(function() { hljs.highlightBlock(this); });
-
-</script>
-<script async src="//www.google-analytics.com/analytics.js"></script>


### PR DESCRIPTION
## Remove Google Analytics

If you must have an analytics system, might I suggest either:
- Plausible: https://plausible.io (offers a 50% discount for FOSS projects)
- Goatcounter: https://goatcounter.com
- Matomo: https://matomo.org
- Fathom: https://usefathom.org

These solutions are all well-tested and open-source. This, of course, means they
can be independently audited for privacy and security. Instead of using a proprietary
nonfree system such as Google Analytics, perhaps we could work together to replace
it with something slightly more ethical?

Furthermore, the majority of privacy features in evergreen browsers *block* Google
Analytics from being run. I can not say the same for solutions such as Plausible,
which suggests they are trusted for their privacy by independent persons.

If you need any more information, please contact me!