### PR TITLE
Fix Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,7 @@ function moved() {
       </a>
     </li>
     <li style="list-style-image: url('icon-slack.svg');">
-      <a href="https://d3-slackin.herokuapp.com/" title="D3 Slack">
+      <a href="https://join.slack.com/t/d3js/shared_invite/zt-1neihq96a-xkXVPXYOmKg8ou7DL3kr7g" title="D3 Slack">
         Chat with the community
       </a>
     </li>


### PR DESCRIPTION
[This link](https://join.slack.com/t/d3js/shared_invite/zt-1neihq96a-xkXVPXYOmKg8ou7DL3kr7g) is set to "never" expire, but will have to be refreshed when 400 users have used it.